### PR TITLE
[filesManager] Ensure messages order when processing

### DIFF
--- a/apps/core/src/app/core/recordApp.ts
+++ b/apps/core/src/app/core/recordApp.ts
@@ -8,7 +8,7 @@ import {IUtils} from 'utils/utils';
 import {IAppGraphQLSchema} from '_types/graphql';
 import {IQueryInfos} from '_types/queryInfos';
 import {ITree} from '_types/tree';
-import {IFilesManagerDomain, systemPreviewVersions} from '../../domain/filesManager/filesManagerDomain';
+import {IFilesManagerDomain} from '../../domain/filesManager/filesManagerDomain';
 import {RecordPermissionsActions} from '../../_types/permissions';
 import {AttributeCondition, IRecord, TreeCondition} from '../../_types/record';
 import {IGraphqlApp} from '../graphql/graphqlApp';
@@ -80,7 +80,8 @@ export default function ({
                     }
 
                     type Preview {
-                        ${systemPreviewVersions
+                        ${filesManagerDomain
+                            .getPreviewVersion()
                             .reduce((sizes, version) => [...sizes, ...version.sizes.map(s => `${s.name}: String,`)], [])
                             .join(' ')}
                         pages: String

--- a/apps/core/src/domain/filesManager/_constants.ts
+++ b/apps/core/src/domain/filesManager/_constants.ts
@@ -1,0 +1,33 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {IPreviewVersion} from '_types/filesManager';
+
+export const systemPreviewVersions: IPreviewVersion[] = [
+    {
+        background: false,
+        density: 300,
+        sizes: [
+            {
+                size: 64,
+                name: 'tiny'
+            },
+            {
+                size: 128,
+                name: 'small'
+            },
+            {
+                size: 256,
+                name: 'medium'
+            },
+            {
+                size: 512,
+                name: 'big'
+            },
+            {
+                size: 1024,
+                name: 'huge'
+            }
+        ]
+    }
+];

--- a/apps/core/src/domain/filesManager/filesManagerDomain.spec.ts
+++ b/apps/core/src/domain/filesManager/filesManagerDomain.spec.ts
@@ -1,6 +1,7 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {amqpService, IAmqpService} from '@leav/message-broker';
 import * as amqp from 'amqplib';
 import {IRecordDomain} from 'domain/record/recordDomain';
 import {ITreeDomain} from 'domain/tree/treeDomain';
@@ -11,9 +12,9 @@ import {IQueryInfos} from '_types/queryInfos';
 import ValidationError from '../../errors/ValidationError';
 import {mockRecord} from '../../__tests__/mocks/record';
 import {mockTranslator} from '../../__tests__/mocks/translator';
-import {IAmqpService, amqpService} from '@leav/message-broker';
-import filesManager, {systemPreviewVersions} from './filesManagerDomain';
+import filesManager from './filesManagerDomain';
 import {createPreview} from './helpers/handlePreview';
+import {systemPreviewVersions} from './_constants';
 import winston = require('winston');
 
 const mockConfig: Mockify<Config.IConfig> = {

--- a/apps/core/src/domain/filesManager/helpers/handleFileSystem.ts
+++ b/apps/core/src/domain/filesManager/helpers/handleFileSystem.ts
@@ -1,26 +1,25 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {IAmqpService} from '@leav/message-broker';
 import {IRecordDomain} from 'domain/record/recordDomain';
 import {ITreeDomain} from 'domain/tree/treeDomain';
 import {IValueDomain} from 'domain/value/valueDomain';
-import {IAmqpService} from '@leav/message-broker';
 import {IUtils} from 'utils/utils';
 import * as Config from '_types/config';
-import {FileEvents, IFileEventData, IPreviewVersion} from '../../../_types/filesManager';
+import {IQueryInfos} from '_types/queryInfos';
+import {FileEvents, IFileEventData} from '../../../_types/filesManager';
 import {handleCreateEvent} from './handleFileSystem/handleCreateEvent';
 import {handleMoveEvent} from './handleFileSystem/handleMoveEvent';
 import {handleRemoveEvent} from './handleFileSystem/handleRemoveEvent';
 import {handleUpdateEvent} from './handleFileSystem/handleUpdateEvent';
 import winston = require('winston');
-import {IQueryInfos} from '_types/queryInfos';
 
 export interface IHandleFileSystemDeps {
     recordDomain: IRecordDomain;
     valueDomain: IValueDomain;
     treeDomain: ITreeDomain;
     amqpService: IAmqpService;
-    previewVersions: IPreviewVersion[];
     logger: winston.Winston;
     config: Config.IConfig;
     utils: IUtils;

--- a/apps/core/src/domain/filesManager/helpers/handleFileSystem/handleCreateEvent.ts
+++ b/apps/core/src/domain/filesManager/helpers/handleFileSystem/handleCreateEvent.ts
@@ -1,6 +1,8 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {IQueryInfos} from '_types/queryInfos';
+import {systemPreviewVersions} from '../../../../domain/filesManager/_constants';
 import {IFileEventData, IFilesAttributes} from '../../../../_types/filesManager';
 import {IHandleFileSystemDeps, IHandleFileSystemResources} from '../handleFileSystem';
 import {
@@ -13,7 +15,6 @@ import {
     updateRecordFile
 } from '../handleFileUtilsHelper';
 import {createPreview} from '../handlePreview';
-import {IQueryInfos} from '_types/queryInfos';
 
 export const handleCreateEvent = async (
     scanMsg: IFileEventData,
@@ -27,7 +28,7 @@ export const handleCreateEvent = async (
     let record = await getRecord(fileName, filePath, resources.library, true, deps, ctx);
 
     // Preview and Previews status
-    const {previewsStatus, previews} = getPreviewsDatas(deps.previewVersions);
+    const {previewsStatus, previews} = getPreviewsDatas(systemPreviewVersions);
 
     if (record) {
         try {
@@ -78,7 +79,7 @@ export const handleCreateEvent = async (
             record.id,
             scanMsg.pathAfter,
             resources.library,
-            deps.previewVersions,
+            systemPreviewVersions,
             deps.amqpService,
             deps.config
         );

--- a/apps/core/src/domain/filesManager/helpers/handleFileSystem/handleUpdateEvent.ts
+++ b/apps/core/src/domain/filesManager/helpers/handleFileSystem/handleUpdateEvent.ts
@@ -1,11 +1,12 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {IQueryInfos} from '_types/queryInfos';
+import {systemPreviewVersions} from '../../../../domain/filesManager/_constants';
 import {IFileEventData, IFilesAttributes} from '../../../../_types/filesManager';
 import {IHandleFileSystemDeps, IHandleFileSystemResources} from '../handleFileSystem';
 import {getInputData, getPreviewsDatas, getRecord, updateRecordFile} from '../handleFileUtilsHelper';
 import {createPreview} from '../handlePreview';
-import {IQueryInfos} from '_types/queryInfos';
 
 export const handleUpdateEvent = async (
     scanMsg: IFileEventData,
@@ -23,7 +24,7 @@ export const handleUpdateEvent = async (
         return;
     }
 
-    const {previewsStatus, previews} = getPreviewsDatas(deps.previewVersions);
+    const {previewsStatus, previews} = getPreviewsDatas(systemPreviewVersions);
 
     const recordData: IFilesAttributes = {
         INODE: scanMsg.inode,
@@ -37,5 +38,5 @@ export const handleUpdateEvent = async (
     await updateRecordFile(recordData, record.id, library, deps, ctx);
 
     // Regenerate Previews
-    await createPreview(record.id, scanMsg.pathAfter, library, deps.previewVersions, deps.amqpService, deps.config);
+    await createPreview(record.id, scanMsg.pathAfter, library, systemPreviewVersions, deps.amqpService, deps.config);
 };

--- a/apps/core/src/domain/filesManager/helpers/messagesHandler/index.ts
+++ b/apps/core/src/domain/filesManager/helpers/messagesHandler/index.ts
@@ -1,0 +1,4 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+export {default} from './messagesHandler';

--- a/apps/core/src/domain/filesManager/helpers/messagesHandler/messagesHandler.spec.ts
+++ b/apps/core/src/domain/filesManager/helpers/messagesHandler/messagesHandler.spec.ts
@@ -1,0 +1,58 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {IConfig} from '_types/config';
+import {FileEvents, IFileEventData} from '../../../../_types/filesManager';
+import {mockCtx} from '../../../../__tests__/mocks/shared';
+import * as handleFileSystem from '../handleFileSystem';
+import messagesHandler from './messagesHandler';
+
+describe('MessagesHandler', () => {
+    test('Process messages, respect incoming order', async () => {
+        const mockHandleEventFileSystem = jest.fn();
+        jest.spyOn(handleFileSystem, 'handleEventFileSystem').mockImplementation(mockHandleEventFileSystem);
+
+        const mockConfig = {
+            filesManager: {
+                rootKeys: {
+                    files1: 'files'
+                }
+            }
+        };
+
+        const handler = messagesHandler({
+            config: mockConfig as IConfig
+        });
+
+        const mockMessage: IFileEventData = {
+            event: FileEvents.CREATE,
+            inode: 0,
+            isDirectory: false,
+            pathAfter: '/path/to/file/1',
+            pathBefore: '',
+            rootKey: 'root_key',
+            time: 123456789,
+            hash: 'hash'
+        };
+
+        try {
+            handler.handleMessage({...mockMessage, inode: 1}, mockCtx);
+            handler.handleMessage({...mockMessage, inode: 2}, mockCtx);
+            handler.handleMessage({...mockMessage, inode: 3}, mockCtx);
+            handler.handleMessage({...mockMessage, inode: 4}, mockCtx);
+            handler.handleMessage({...mockMessage, inode: 5}, mockCtx);
+        } catch (e) {
+            console.error(e);
+        }
+
+        // Actual messages processing is asynchronous. Just wait a little to make sure it's done.
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockHandleEventFileSystem).toHaveBeenCalledTimes(5);
+        expect(mockHandleEventFileSystem.mock.calls[0][0].inode).toBe(1);
+        expect(mockHandleEventFileSystem.mock.calls[1][0].inode).toBe(2);
+        expect(mockHandleEventFileSystem.mock.calls[2][0].inode).toBe(3);
+        expect(mockHandleEventFileSystem.mock.calls[3][0].inode).toBe(4);
+        expect(mockHandleEventFileSystem.mock.calls[4][0].inode).toBe(5);
+    });
+});

--- a/apps/core/src/domain/filesManager/helpers/messagesHandler/messagesHandler.ts
+++ b/apps/core/src/domain/filesManager/helpers/messagesHandler/messagesHandler.ts
@@ -1,0 +1,86 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {IAmqpService} from '@leav/message-broker';
+import {IRecordDomain} from 'domain/record/recordDomain';
+import {ITreeDomain} from 'domain/tree/treeDomain';
+import {IValueDomain} from 'domain/value/valueDomain';
+import {IUtils} from 'utils/utils';
+import winston from 'winston';
+import {IConfig} from '_types/config';
+import {IFileEventData} from '_types/filesManager';
+import {IQueryInfos} from '_types/queryInfos';
+import {handleEventFileSystem} from '../handleFileSystem';
+
+export interface IMessagesHandlerHelper {
+    handleMessage(message: IFileEventData, ctx: IQueryInfos);
+}
+
+interface IDeps {
+    'core.infra.amqpService'?: IAmqpService;
+    'core.utils.logger'?: winston.Winston;
+    'core.domain.record'?: IRecordDomain;
+    'core.domain.value'?: IValueDomain;
+    'core.domain.tree'?: ITreeDomain;
+    'core.utils'?: IUtils;
+    config?: IConfig;
+}
+
+// Handle messages: new messages are stacked in a queue. Then we process them one by one.
+// The purpose is to make sure we process message in the same order they are received.
+// Otherwise, we may have a situation where we try to add a file to a directory,
+// but the directory is not yet created.
+export default function ({
+    config = null,
+    'core.infra.amqpService': amqpService = null,
+    'core.utils.logger': logger = null,
+    'core.domain.record': recordDomain = null,
+    'core.domain.value': valueDomain = null,
+    'core.domain.tree': treeDomain = null,
+    'core.utils': utils = null
+}: IDeps): IMessagesHandlerHelper {
+    const _messagesQueue: IFileEventData[] = [];
+    let _isWorking: boolean = false;
+
+    const _processMessage = async (ctx: IQueryInfos): Promise<void> => {
+        if (_isWorking || !_messagesQueue.length) {
+            return;
+        }
+
+        _isWorking = true;
+
+        const message = _messagesQueue.shift();
+
+        try {
+            const library = config.filesManager.rootKeys[message.rootKey];
+            await handleEventFileSystem(
+                message,
+                {library},
+                {
+                    recordDomain,
+                    valueDomain,
+                    treeDomain,
+                    amqpService,
+                    logger,
+                    config,
+                    utils
+                },
+                ctx
+            );
+        } catch (e) {
+            console.error(e);
+            logger.error(`[FilesManager] Error when processing file event msg:${e.message}. Message was: ${message}`);
+        }
+
+        _isWorking = false;
+        _processMessage(ctx);
+    };
+
+    return {
+        handleMessage(message, ctx) {
+            _messagesQueue.push(message);
+
+            _processMessage(ctx);
+        }
+    };
+}


### PR DESCRIPTION
We now have an internal FIFO queue. Incoming messages are stacked in this queue and we process them one by one.