### PR TITLE
[core] Improve schema refresh

### DIFF
--- a/apps/core/src/_types/event.ts
+++ b/apps/core/src/_types/event.ts
@@ -8,7 +8,7 @@ import {IValue} from './value';
 export interface IEvent {
     time: number;
     userId: string;
-    emitterPid: number;
+    emitter: string;
 }
 
 export type PublishedEvent<T> = IEvent & T;

--- a/apps/core/src/_types/event.ts
+++ b/apps/core/src/_types/event.ts
@@ -8,6 +8,7 @@ import {IValue} from './value';
 export interface IEvent {
     time: number;
     userId: string;
+    emitterPid: number;
 }
 
 export type PublishedEvent<T> = IEvent & T;
@@ -19,6 +20,8 @@ export enum EventAction {
     RECORD_DELETE = 'RECORD_DELETE',
     LIBRARY_SAVE = 'LIBRARY_SAVE',
     LIBRARY_DELETE = 'LIBRARY_DELETE',
+    ATTRIBUTE_SAVE = 'ATTRIBUTE_SAVE',
+    ATTRIBUTE_DELETE = 'ATTRIBUTE_DELETE',
     VALUE_SAVE = 'VALUE_SAVE',
     VALUE_DELETE = 'VALUE_DELETE'
 }

--- a/apps/core/src/app/core/coreApp.ts
+++ b/apps/core/src/app/core/coreApp.ts
@@ -1,25 +1,28 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
-import {ISystemTranslationGenerator} from 'app/graphql/customScalars/systemTranslation/systemTranslation';
-import {ICoreDomain} from 'domain/core/coreDomain';
-import {constants, promises as fs} from 'fs';
-import {GraphQLScalarType, Kind} from 'graphql';
-import GraphQLJSON, {GraphQLJSONObject} from 'graphql-type-json';
-import {i18n} from 'i18next';
 import {IAppGraphQLSchema} from '_types/graphql';
 import {IQueryInfos} from '_types/queryInfos';
 import {IAppModule} from '_types/shared';
 import {ISystemTranslation} from '_types/systemTranslation';
+import {ISystemTranslationGenerator} from 'app/graphql/customScalars/systemTranslation/systemTranslation';
+import {ICoreDomain} from 'domain/core/coreDomain';
+import {IEventsManagerDomain} from 'domain/eventsManager/eventsManagerDomain';
+import {constants, promises as fs} from 'fs';
+import {GraphQLScalarType, Kind} from 'graphql';
+import GraphQLJSON, {GraphQLJSONObject} from 'graphql-type-json';
+import {i18n} from 'i18next';
 import {IGraphqlApp} from '../graphql/graphqlApp';
 
 export interface ICoreApp extends IAppModule {
     getGraphQLSchema(): Promise<IAppGraphQLSchema>;
     filterSysTranslationField(fieldData: ISystemTranslation, requestedLangs: string[]): ISystemTranslation;
+    initPubSubEventsConsumer(): Promise<void>;
 }
 
 interface IDeps {
     'core.domain.core'?: ICoreDomain;
+    'core.domain.eventsManager'?: IEventsManagerDomain;
     'core.app.graphql'?: IGraphqlApp;
     'core.app.graphql.customScalars.systemTranslation'?: ISystemTranslationGenerator;
     'core.app.graphql.customScalars.dateTime'?: GraphQLScalarType;
@@ -53,6 +56,7 @@ const _parseLiteralAny = ast => {
 export default function (
     {
         'core.domain.core': coreDomain = null,
+        'core.domain.eventsManager': eventsManagerDomain = null,
         'core.app.graphql': graphqlApp = null,
         'core.app.graphql.customScalars.systemTranslation': systemTranslation = null,
         'core.app.graphql.customScalars.dateTime': DateTime = null,
@@ -138,6 +142,9 @@ export default function (
                     allLabel[labelLang] = fieldData[labelLang];
                     return allLabel;
                 }, {});
+        },
+        async initPubSubEventsConsumer() {
+            return eventsManagerDomain.initPubSubEventsConsumer();
         },
         extensionPoints: {
             /**

--- a/apps/core/src/app/graphql/graphqlApp.ts
+++ b/apps/core/src/app/graphql/graphqlApp.ts
@@ -150,7 +150,7 @@ export default function ({
                 async (msg: ConsumeMessage, channel: ConfirmChannel) => {
                     channel.ack(msg);
                     const msgContent: IDbEvent = JSON.parse(msg.content.toString());
-                    if (msgContent.emitterPid === process.pid) {
+                    if (msgContent.emitter === utils.getProcessIdentifier()) {
                         // No need to refresh if we are the emitter. Refresh has already been done
                         return;
                     }

--- a/apps/core/src/domain/eventsManager/eventsManagerDomain.spec.ts
+++ b/apps/core/src/domain/eventsManager/eventsManagerDomain.spec.ts
@@ -5,6 +5,7 @@ import {IAmqpService} from '@leav/message-broker';
 import {IConfig} from '_types/config';
 import {IQueryInfos} from '_types/queryInfos';
 import * as amqp from 'amqplib';
+import {IUtils} from 'utils/utils';
 import {EventAction} from '../../_types/event';
 import eventsManager from './eventsManagerDomain';
 import winston = require('winston');
@@ -81,6 +82,10 @@ describe('Events Manager', () => {
         close: jest.fn()
     };
 
+    const mockUtils: Mockify<IUtils> = {
+        getProcessIdentifier: jest.fn().mockReturnValue('98765431-42')
+    };
+
     test('Init', async () => {
         const events = eventsManager({
             config: conf as IConfig,
@@ -96,7 +101,8 @@ describe('Events Manager', () => {
     test('send database event', async () => {
         const events = eventsManager({
             config: conf as IConfig,
-            'core.infra.amqpService': mockAmqpService as IAmqpService
+            'core.infra.amqpService': mockAmqpService as IAmqpService,
+            'core.utils': mockUtils as IUtils
         });
 
         await events.sendDatabaseEvent({action: EventAction.LIBRARY_SAVE, data: {new: {id: 'test'}}}, ctx);
@@ -107,7 +113,8 @@ describe('Events Manager', () => {
     test('send pubsub event', async () => {
         const events = eventsManager({
             config: conf as IConfig,
-            'core.infra.amqpService': mockAmqpService as IAmqpService
+            'core.infra.amqpService': mockAmqpService as IAmqpService,
+            'core.utils': mockUtils as IUtils
         });
 
         await events.sendPubSubEvent({triggerName: 'test', data: {}}, ctx);

--- a/apps/core/src/domain/eventsManager/eventsManagerDomain.spec.ts
+++ b/apps/core/src/domain/eventsManager/eventsManagerDomain.spec.ts
@@ -1,10 +1,10 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
-import * as amqp from 'amqplib';
+import {IAmqpService} from '@leav/message-broker';
 import {IConfig} from '_types/config';
 import {IQueryInfos} from '_types/queryInfos';
-import {IAmqpService, amqpService} from '@leav/message-broker';
+import * as amqp from 'amqplib';
 import {EventAction} from '../../_types/event';
 import eventsManager from './eventsManagerDomain';
 import winston = require('winston');
@@ -88,7 +88,7 @@ describe('Events Manager', () => {
             'core.infra.amqpService': mockAmqpService as IAmqpService
         });
 
-        await events.init();
+        await events.initPubSubEventsConsumer();
 
         expect(mockAmqpService.consume).toBeCalledTimes(1);
     });

--- a/apps/core/src/domain/indexationManager/indexationManagerDomain.ts
+++ b/apps/core/src/domain/indexationManager/indexationManagerDomain.ts
@@ -353,7 +353,7 @@ export default function ({
         const msgBodySchema = Joi.object().keys({
             time: Joi.number().required(),
             userId: Joi.string().required(),
-            emitterPid: Joi.number().required(),
+            emitter: Joi.string().required(),
             payload: Joi.object()
                 .keys({
                     action: Joi.string()

--- a/apps/core/src/domain/indexationManager/indexationManagerDomain.ts
+++ b/apps/core/src/domain/indexationManager/indexationManagerDomain.ts
@@ -1,22 +1,22 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
-import Joi from 'joi';
+import {IAmqpService} from '@leav/message-broker';
+import * as Config from '_types/config';
+import {IQueryInfos} from '_types/queryInfos';
+import {IValue} from '_types/value';
+import * as amqp from 'amqplib';
 import {IAttributeDomain} from 'domain/attribute/attributeDomain';
 import {ILibraryDomain} from 'domain/library/libraryDomain';
 import {IFindRecordParams, IRecordDomain} from 'domain/record/recordDomain';
 import {IRecordRepo} from 'infra/record/recordRepo';
-import {IAmqpService} from '@leav/message-broker';
+import Joi from 'joi';
 import {isEqual, pick} from 'lodash';
 import {v4 as uuidv4} from 'uuid';
-import * as Config from '_types/config';
-import {IQueryInfos} from '_types/queryInfos';
-import {IValue} from '_types/value';
 import {AttributeTypes, IAttribute, IAttributeFilterOptions} from '../../_types/attribute';
 import {EventAction, IDbEvent, ILibraryPayload, IRecordPayload, IValuePayload} from '../../_types/event';
 import {AttributeCondition, Operator} from '../../_types/record';
 import {CORE_INDEX_FIELD, IIndexationService} from '../../infra/indexation/indexationService';
-import * as amqp from 'amqplib';
 
 export interface IIndexationManagerDomain {
     init(): Promise<void>;
@@ -353,6 +353,7 @@ export default function ({
         const msgBodySchema = Joi.object().keys({
             time: Joi.number().required(),
             userId: Joi.string().required(),
+            emitterPid: Joi.number().required(),
             payload: Joi.object()
                 .keys({
                     action: Joi.string()

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -4,10 +4,12 @@
 import {amqpService} from '@leav/message-broker';
 import fs from 'fs';
 // import {IApplicationService} from 'infra/application/applicationService';
+import * as Config from '_types/config';
 import {IFilesManagerInterface} from 'interface/filesManager';
 import {IIndexationManagerInterface} from 'interface/indexationManager';
+import {IServer} from 'interface/server';
 import {ITasksManagerInterface} from 'interface/tasksManager';
-import * as Config from '_types/config';
+import minimist from 'minimist';
 import {getConfig, validateConfig} from './config';
 import {initDI} from './depsManager';
 import i18nextInit from './i18nextInit';
@@ -15,7 +17,6 @@ import {initRedis} from './infra/cache';
 import {initDb} from './infra/db/db';
 import {initMailer} from './infra/mailer';
 import {initPlugins} from './pluginsLoader';
-import minimist from 'minimist';
 
 (async function () {
     const opt = minimist(process.argv.slice(2));
@@ -49,7 +50,7 @@ import minimist from 'minimist';
         'core.infra.mailer': mailer
     });
 
-    const server = coreContainer.cradle['core.interface.server'];
+    const server: IServer = coreContainer.cradle['core.interface.server'];
     const filesManager: IFilesManagerInterface = coreContainer.cradle['core.interface.filesManager'];
     const indexationManager: IIndexationManagerInterface = coreContainer.cradle['core.interface.indexationManager'];
     const tasksManager: ITasksManagerInterface = coreContainer.cradle['core.interface.tasksManager'];
@@ -82,8 +83,7 @@ import minimist from 'minimist';
 
         if (opt.server) {
             await server.init();
-
-            await eventsManager.init();
+            await server.initConsumers();
         } else if (opt.migrate) {
             // Run db migrations
             await dbUtils.migrate(coreContainer);

--- a/apps/core/src/utils/utils.ts
+++ b/apps/core/src/utils/utils.ts
@@ -1,16 +1,17 @@
 // Copyright LEAV Solutions 2017
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {IActionsListConfig} from '_types/actionsList';
+import {ErrorFieldDetail, ErrorFieldDetailMessage, Errors, IExtendedErrorMsg} from '_types/errors';
+import {LibraryBehavior} from '_types/library';
 import fs from 'fs';
 import {i18n} from 'i18next';
 import {camelCase, flow, mergeWith, partialRight, trimEnd, upperFirst} from 'lodash';
 import moment from 'moment';
-import {IActionsListConfig} from '_types/actionsList';
-import {ErrorFieldDetail, ErrorFieldDetailMessage, Errors, IExtendedErrorMsg} from '_types/errors';
-import {LibraryBehavior} from '_types/library';
-import ValidationError from '../errors/ValidationError';
+import os from 'os';
 import {APPS_URL_PREFIX} from '../_types/application';
 import {AttributeTypes, IAttribute} from '../_types/attribute';
+import ValidationError from '../errors/ValidationError';
 import getDefaultActionsList from './helpers/getDefaultActionsList';
 import getLibraryDefaultAttributes from './helpers/getLibraryDefaultAttributes';
 
@@ -110,6 +111,8 @@ export interface IUtils {
     getUnixTime(): number;
 
     getFileExtension(filename: string): string | null;
+
+    getProcessIdentifier(): string;
 }
 
 export interface IUtilsDeps {
@@ -263,6 +266,9 @@ export default function ({translator = null}: IUtilsDeps = {}): IUtils {
 
             //TODO: test this
             return new ValidationError<T>(fieldDetails, this.translateError(message, lang));
+        },
+        getProcessIdentifier(): string {
+            return `${os.hostname()}-${process.pid}`;
         }
     };
 }

--- a/libs/ui/src/hooks/useSharedTranslation/__mocks__/index.ts
+++ b/libs/ui/src/hooks/useSharedTranslation/__mocks__/index.ts
@@ -1,1 +1,4 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
 export {default as useSharedTranslation} from './useSharedTranslation';

--- a/libs/ui/src/hooks/useSharedTranslation/__mocks__/useSharedTranslation.ts
+++ b/libs/ui/src/hooks/useSharedTranslation/__mocks__/useSharedTranslation.ts
@@ -1,3 +1,6 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
 import {Mockify} from '@leav/utils';
 import {TFunction, i18n} from 'i18next';
 

--- a/libs/ui/src/hooks/useSharedTranslation/index.ts
+++ b/libs/ui/src/hooks/useSharedTranslation/index.ts
@@ -1,1 +1,4 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
 export {default as useSharedTranslation} from './useSharedTranslation';

--- a/libs/ui/src/hooks/useSharedTranslation/useSharedTranslation.ts
+++ b/libs/ui/src/hooks/useSharedTranslation/useSharedTranslation.ts
@@ -1,3 +1,6 @@
+// Copyright LEAV Solutions 2017
+// This file is released under LGPL V3
+// License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import {useContext, useMemo} from 'react';


### PR DESCRIPTION
Add RabbitMQ consumer to refresh schema on library or attribute events, no matter where they come from (other core process, worker...)