### PR TITLE
[data-studio] Improve form refresh on record edit

### DIFF
--- a/apps/core/src/_types/forms.ts
+++ b/apps/core/src/_types/forms.ts
@@ -16,6 +16,7 @@ export interface IRecordForm {
     library: string;
     system: boolean;
     recordId: string;
+    dependencyAttributes?: string[];
     elements: IFormElementWithValues[];
 }
 

--- a/apps/core/src/domain/form/formDomain.spec.ts
+++ b/apps/core/src/domain/form/formDomain.spec.ts
@@ -423,6 +423,7 @@ describe('formDomain', () => {
                 library: 'my_lib',
                 recordId: '123456',
                 system: false,
+                dependencyAttributes: [],
                 elements: [
                     {...mockContainer, valueError: null, values: null},
                     {...field1, valueError: null, values: [mockStandardValue]},
@@ -467,6 +468,7 @@ describe('formDomain', () => {
                 library: 'my_lib',
                 recordId: '123456',
                 system: false,
+                dependencyAttributes: [],
                 elements: [
                     {...mockContainer, valueError: null, values: null},
                     {...field1, values: null, valueError: 'boom!'}
@@ -508,6 +510,7 @@ describe('formDomain', () => {
                 library: 'my_lib',
                 recordId: '123456',
                 system: false,
+                dependencyAttributes: [],
                 elements: [
                     {...mockContainer, valueError: null, values: null},
                     {...field1, values: null, valueError: 'boom!'}
@@ -580,6 +583,7 @@ describe('formDomain', () => {
                 library: 'my_lib',
                 recordId: '123456',
                 system: false,
+                dependencyAttributes: [],
                 elements: [
                     {...formField, containerId: FORM_ROOT_CONTAINER_ID, valueError: null, values: [mockStandardValue]},
                     {...mockDepField1, valueError: null, values: [mockStandardValue]}
@@ -655,6 +659,7 @@ describe('formDomain', () => {
                 library: 'my_lib',
                 recordId: '123456',
                 system: false,
+                dependencyAttributes: [],
                 elements: [
                     {...formField, containerId: FORM_ROOT_CONTAINER_ID, valueError: null, values: [mockStandardValue]},
                     {...mockDepField1, valueError: null, values: [mockStandardValue]},
@@ -746,6 +751,7 @@ describe('formDomain', () => {
                 library: 'my_lib',
                 recordId: '123456',
                 system: false,
+                dependencyAttributes: [],
                 elements: [
                     {...filledContainer, valueError: null, values: null},
                     {...mockField1, valueError: null, values: [mockStandardValue]}
@@ -868,6 +874,7 @@ describe('formDomain', () => {
                 library: 'my_lib',
                 recordId: '123456',
                 system: false,
+                dependencyAttributes: [],
                 elements: [
                     {
                         ...mockTabs1,

--- a/apps/core/src/domain/form/formDomain.ts
+++ b/apps/core/src/domain/form/formDomain.ts
@@ -350,6 +350,7 @@ export default function (deps: IDeps = {}): IFormDomain {
                 recordId,
                 system: formProps.system,
                 library: libraryId,
+                dependencyAttributes: formProps.dependencyAttributes,
                 elements: formElements
             };
         },

--- a/apps/data-studio/src/__mocks__/common/form.tsx
+++ b/apps/data-studio/src/__mocks__/common/form.tsx
@@ -282,5 +282,6 @@ export const mockRecordForm: IRecordForm = {
         id: 'test_lib'
     },
     recordId: '123456',
+    dependencyAttributes: [],
     elements: [{...mockFormElementInput, settings: [{key: 'my_settings', value: 'value'}]}]
 };

--- a/apps/data-studio/src/_gqlTypes/RECORD_FORM.ts
+++ b/apps/data-studio/src/_gqlTypes/RECORD_FORM.ts
@@ -23,6 +23,10 @@ export interface RECORD_FORM_recordForm_library {
     id: string;
 }
 
+export interface RECORD_FORM_recordForm_dependencyAttributes {
+    id: string;
+}
+
 export interface RECORD_FORM_recordForm_elements_values_Value_created_by_whoAmI_library_gqlNames {
     query: string;
     type: string;
@@ -1095,6 +1099,7 @@ export interface RECORD_FORM_recordForm {
     id: string;
     recordId: string | null;
     library: RECORD_FORM_recordForm_library;
+    dependencyAttributes: RECORD_FORM_recordForm_dependencyAttributes[] | null;
     elements: RECORD_FORM_recordForm_elements[];
 }
 

--- a/apps/data-studio/src/components/RecordEdition/EditRecord/EditRecord.test.tsx
+++ b/apps/data-studio/src/components/RecordEdition/EditRecord/EditRecord.test.tsx
@@ -30,6 +30,7 @@ describe('EditRecord', () => {
                     data: {
                         recordForm: {
                             __typename: 'RecordForm',
+                            dependencyAttributes: [],
                             id: mockRecordForm.id,
                             recordId: '123456',
                             library: mockRecordForm.library,

--- a/apps/data-studio/src/graphQL/queries/forms/getRecordFormQuery.ts
+++ b/apps/data-studio/src/graphQL/queries/forms/getRecordFormQuery.ts
@@ -33,6 +33,9 @@ export const getRecordFormQuery = gql`
             library {
                 id
             }
+            dependencyAttributes {
+                id
+            }
             elements {
                 id
                 containerId


### PR DESCRIPTION
Automatically refresh form if we change a value on a dependency attribute