### PR TITLE
fix(@leav/ui): display the right color when inputnumber is readonly

### DIFF
--- a/libs/ui/src/components/RecordEdition/EditRecordContent/uiElements/StandardField/StandardFieldValue/DSInputNumberWrapper.tsx
+++ b/libs/ui/src/components/RecordEdition/EditRecordContent/uiElements/StandardField/StandardFieldValue/DSInputNumberWrapper.tsx
@@ -11,10 +11,7 @@ import {useSharedTranslation} from '_ui/hooks/useSharedTranslation';
 
 const KitInputNumberStyled = styled(KitInputNumber)<{$shouldHighlightColor: boolean}>`
     width: 100%;
-    .ant-input-number-input-wrap .ant-input-number-input {
-        color: ${({$shouldHighlightColor}) =>
-            $shouldHighlightColor ? 'var(--general-colors-primary-400)' : 'initial'};
-    }
+    color: ${({$shouldHighlightColor}) => ($shouldHighlightColor ? 'var(--general-colors-primary-400)' : 'initial')};
 `;
 
 export const DSInputNumberWrapper: FunctionComponent<IStandFieldValueContentProps<KitInputNumberProps>> = ({


### PR DESCRIPTION
## Checklist

Definition Of Review

-   [x] Own code review done (add notes for others)
-   [x] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core - DataStudio - Admin - @leav/ui - @leav/utils - ...

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
