### PR TITLE
fix: refresh data on edit explorer

### DIFF
--- a/libs/ui/src/components/Explorer/Explorer.tsx
+++ b/libs/ui/src/components/Explorer/Explorer.tsx
@@ -199,7 +199,8 @@ export const Explorer = forwardRef<IExplorerRef, IExplorerProps>(
         const {editItemAction, editItemModal} = useEditItemAction({
             isEnabled: isNotEmpty(defaultActionsForItem) && defaultActionsForItem.includes('edit'),
             onEdit: defaultCallbacks?.item?.edit,
-            formId: editionFormId
+            formId: editionFormId,
+            refetch
         });
 
         const totalCount = data?.totalCount ?? 0;

--- a/libs/ui/src/components/Explorer/actions-item/useEditItemAction.tsx
+++ b/libs/ui/src/components/Explorer/actions-item/useEditItemAction.tsx
@@ -22,10 +22,12 @@ import {EDIT_RECORD_MODAL_CLASSNAME} from '../_constants';
 export const useEditItemAction = ({
     isEnabled,
     formId,
-    onEdit
+    onEdit,
+    refetch
 }: FeatureHook<{
     onEdit?: IItemAction['callback'];
     formId?: string;
+    refetch: () => void;
 }>) => {
     const {t} = useSharedTranslation();
 
@@ -42,6 +44,7 @@ export const useEditItemAction = ({
     };
 
     const _handleEditModalClose = (item: IItemData) => {
+        refetch();
         refreshItem({
             variables: {
                 libraryId: item.libraryId,


### PR DESCRIPTION
## Checklist

Definition Of Review

-   [x] Own code review done (add notes for others)
-   [x] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : @leav/ui

    📖 Ticket: https://aristid.atlassian.net/jira/software/c/projects/AMONT/boards/342?selectedIssue=LEAVC-91

    🧑‍💻 PR: https://github.com/leav-solutions/leav-engine/compare/fix/LEAVC-91/refresh-data-onchange-explorer?expand=1

    ℹ Info: Fix the refresh of the data when editing in explorer 
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
