### PR TITLE
feat(core): add errorId property in LeavError

### DIFF
--- a/apps/core/src/errors/LeavError.ts
+++ b/apps/core/src/errors/LeavError.ts
@@ -1,6 +1,7 @@
 // Copyright LEAV Solutions 2017 until 2023/11/05, Copyright Aristid from 2023/11/06
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
+import {v1 as uuidv1} from 'uuid';
 import {ErrorFieldDetail, ErrorTypes} from '../_types/errors';
 
 interface ILeavErrorRecord {
@@ -20,6 +21,12 @@ export default class LeavError<T, E = ErrorTypes> extends Error {
     public fields?: ErrorFieldDetail<T>;
     public type: E;
     public record?: ILeavErrorRecord;
+    /**
+     * Use this ID to identify the error in logs or for debugging purposes.
+     * It is generated using uuid v1, which includes a timestamp and a unique identifier.
+     * This allows for tracking the error across different systems and logs.
+     */
+    public errorId: string;
 
     public constructor(type: E, message = 'Action forbidden', details?: ILeavErrorDetails) {
         super(message);
@@ -27,5 +34,6 @@ export default class LeavError<T, E = ErrorTypes> extends Error {
         this.type = type;
         this.fields = details?.fields;
         this.record = details?.record;
+        this.errorId = uuidv1();
     }
 }


### PR DESCRIPTION
- to track error across different systems and logs
- if needed, we could add a getter to LeavError for that errorId to avoid generate these ids for each instance

## Checklist

Definition Of Review

-   [x] Own code review done (add notes for others)
-   [x] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
