### PR TITLE
fix(core): ensure `createRecord` returns detailed information in valuesErrors

### DIFF
--- a/apps/core/src/domain/record/_types.ts
+++ b/apps/core/src/domain/record/_types.ts
@@ -2,6 +2,7 @@
 // This file is released under LGPL V3
 // License text available at https://www.gnu.org/licenses/lgpl-3.0.txt
 import {ErrorTypes} from '@leav/utils';
+import {Errors} from '_types/errors';
 import {ICursorPaginationParams, IPaginationParams} from '_types/list';
 import {IRecord, IRecordFilterLight, IRecordSortLight} from '_types/record';
 import {IValue, IValuesOptions, IValueVersion} from '_types/value';
@@ -26,10 +27,10 @@ export interface ICreateRecordParams {
 }
 
 export interface ICreateRecordValueError {
-    attributeId: string;
-    type: ErrorTypes;
+    // Should correspond to GraphQL ValueBatchError
+    attribute: string;
+    type: ErrorTypes | Errors;
     message: string;
-    id_value?: string;
     input?: any;
 }
 

--- a/apps/core/src/domain/record/recordDomain.spec.ts
+++ b/apps/core/src/domain/record/recordDomain.spec.ts
@@ -43,6 +43,7 @@ import recordDomain, {IRecordDomainDeps} from './recordDomain';
 import {IRecordAttributePermissionDomain} from 'domain/permission/recordAttributePermissionDomain';
 import {IAttributePermissionDomain} from 'domain/permission/attributePermissionDomain';
 import * as ValidateValue from '../value/helpers/validateValue';
+import {ICreateRecordValueError} from './_types';
 
 const eventsManagerMockConfig: Mockify<Config.IEventsManager> = {
     routingKeys: {data_events: 'test.data.events', pubsub_events: 'test.pubsub.events'}
@@ -343,7 +344,7 @@ describe('RecordDomain', () => {
                     message: 'mock error',
                     input: 'some other value'
                 }
-            ]);
+            ] as ICreateRecordValueError[]);
         });
 
         test('Should return errors and not create record when try to add no unique value on unique attribute', async () => {
@@ -417,7 +418,7 @@ describe('RecordDomain', () => {
                     message: 'mock error',
                     input: 'some_unique_value'
                 }
-            ]);
+            ] as ICreateRecordValueError[]);
         });
     });
 

--- a/apps/core/src/domain/record/recordDomain.ts
+++ b/apps/core/src/domain/record/recordDomain.ts
@@ -52,7 +52,7 @@ import {IAttributeDomain} from '../attribute/attributeDomain';
 import {IRecordPermissionDomain} from '../permission/recordPermissionDomain';
 import getAttributesFromField from './helpers/getAttributesFromField';
 import {isRecordWithId, SendRecordUpdateEventHelper} from './helpers/sendRecordUpdateEvent';
-import {ICreateRecordResult, IFindRecordParams} from './_types';
+import {ICreateRecordResult, ICreateRecordValueError, IFindRecordParams} from './_types';
 import {IFormRepo} from 'infra/form/formRepo';
 import {IRecordAttributePermissionDomain} from '../permission/recordAttributePermissionDomain';
 import validateValue from '../value/helpers/validateValue';
@@ -890,14 +890,19 @@ export default function ({
                 if (missingAttributes.length) {
                     return {
                         record: null,
-                        valuesErrors: missingAttributes.map(attribute => ({
-                            type: Errors.REQUIRED_ATTRIBUTE,
-                            attribute: attribute.id,
-                            message: utils.translateError(
-                                {msg: Errors.REQUIRED_ATTRIBUTE, vars: {attribute: attributeLabel(attribute.label)}},
-                                ctx.lang
-                            )
-                        }))
+                        valuesErrors: missingAttributes.map(
+                            (attribute): ICreateRecordValueError => ({
+                                type: Errors.REQUIRED_ATTRIBUTE,
+                                attribute: attribute.id,
+                                message: utils.translateError(
+                                    {
+                                        msg: Errors.REQUIRED_ATTRIBUTE,
+                                        vars: {attribute: attributeLabel(attribute.label)}
+                                    },
+                                    ctx.lang
+                                )
+                            })
+                        )
                     };
                 }
             }
@@ -966,8 +971,7 @@ export default function ({
 
                 const errors = res
                     .filter(r => r.status === 'rejected')
-                    .map(err => {
-                        const rejection = err as PromiseRejectedResult;
+                    .map((rejection: PromiseRejectedResult): ICreateRecordValueError => {
                         const errorAttribute = rejection.reason.fields?.attribute;
                         const errorReason = rejection.reason.fields?.[errorAttribute];
 

--- a/apps/core/src/domain/record/recordDomain.ts
+++ b/apps/core/src/domain/record/recordDomain.ts
@@ -972,8 +972,14 @@ export default function ({
                 const errors = res
                     .filter(r => r.status === 'rejected')
                     .map((rejection: PromiseRejectedResult): ICreateRecordValueError => {
-                        const errorAttribute = rejection.reason.fields?.attribute;
-                        const errorReason = rejection.reason.fields?.[errorAttribute];
+                        const errorAttribute =
+                            rejection.reason.fields?.attribute ||
+                            // coming from attributeDomain.getAttributeProperties
+                            rejection.reason.fields?.id?.vars?.attribute;
+                        const errorReason =
+                            rejection.reason.fields?.[errorAttribute] ||
+                            // coming from attributeDomain.getAttributeProperties
+                            rejection.reason.fields?.id;
 
                         return {
                             type: rejection.reason.type,


### PR DESCRIPTION
- based on #929 
- fix `ICreateRecordValueError` type properties: `id_value` not used anymore and `attributeId` renamed to `attribute`
- `createRecord` ensure some errors (for instance the one from  getAttributeProperties) are correctly added in `valuesErrors`

## Checklist

Definition Of Review

-   [x] Own code review done (add notes for others)
-   [x] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core - DataStudio - Admin - @leav/ui - @leav/utils - ...

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
