### PR TITLE
fix(@leav/ui): handle explorer create action on join library behavior

### DIFF
--- a/libs/ui/src/components/Explorer/Explorer.test.tsx
+++ b/libs/ui/src/components/Explorer/Explorer.test.tsx
@@ -496,6 +496,15 @@ describe('Explorer', () => {
             }
         }
     };
+    const mockJoinLibraryDetailsQueryResult: Mockify<typeof gqlTypes.useExplorerLibraryDetailsQuery> = {
+        loading: false,
+        called: true,
+        data: {
+            libraries: {
+                list: [{...mockLibraryDetailsQueryResultList, behavior: gqlTypes.LibraryBehavior.join}]
+            }
+        }
+    };
 
     const mockExplorerAttributesQueryResult: Mockify<typeof gqlTypes.useExplorerAttributesQuery> = {
         loading: false,
@@ -1480,6 +1489,26 @@ describe('Explorer', () => {
             expect(screen.getByText(CreateDirectoryMock)).toBeVisible();
         });
         test('Should be able to create a new record when library has standard behavior', async () => {
+            const onCreate = jest.fn();
+            render(
+                <Explorer.EditSettingsContextProvider panelElement={() => document.body}>
+                    <Explorer entrypoint={libraryEntrypoint} defaultCallbacks={{primary: {create: onCreate}}} />
+                </Explorer.EditSettingsContextProvider>
+            );
+
+            await user.click(screen.getByRole('button', {name: 'explorer.create-one'}));
+
+            expect(screen.getByText(EditRecordModalMock)).toBeVisible();
+            const createRecordButton = screen.getByRole('button', {name: 'create-record'});
+            await user.click(createRecordButton);
+
+            expect(onCreate).toHaveBeenCalledWith({recordIdCreated: 987654});
+        });
+
+        test('Should be able to create a new record when library has join behavior', async () => {
+            jest.spyOn(gqlTypes, 'useExplorerLibraryDetailsQuery').mockImplementation(
+                () => mockJoinLibraryDetailsQueryResult as gqlTypes.ExplorerLibraryDetailsQueryResult
+            );
             const onCreate = jest.fn();
             render(
                 <Explorer.EditSettingsContextProvider panelElement={() => document.body}>

--- a/libs/ui/src/components/Explorer/actions-primary/useCreatePrimaryAction.tsx
+++ b/libs/ui/src/components/Explorer/actions-primary/useCreatePrimaryAction.tsx
@@ -130,6 +130,7 @@ export const useCreatePrimaryAction = ({
             );
             break;
         case LibraryBehavior.standard:
+        case LibraryBehavior.join:
             _createModal = (
                 <EditRecordModal
                     className={CREATE_RECORD_MODAL_CLASSNAME}


### PR DESCRIPTION
Allow to use create button when edit record with linked attribute to a library with **join** behavior.
For instance, in 'campaign' edit form, add a 'structure item' with create action. Link action already  working well.

Before: Click on create do nothing
After: Click on create open creation form, as for standard behavior

For https://aristid.atlassian.net/browse/LEAVC-77

## Checklist

Definition Of Review

-   [x] Own code review done (add notes for others)
-   [x] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core - DataStudio - Admin - @leav/ui - @leav/utils - ...

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
