### PR TITLE
fix(core): Set workerId as null on detach task worker call

### DIFF
--- a/apps/core/src/domain/tasksManager/tasksManagerDomain.ts
+++ b/apps/core/src/domain/tasksManager/tasksManagerDomain.ts
@@ -121,6 +121,7 @@ export default function ({
                 await _sendOrder(config.tasksManager.routingKeys.execOrders, taskToExecute, ctx);
             }
         }, config.tasksManager.checkingInterval);
+
     const _executeTask = async (task: ITask, ctx: IQueryInfos): Promise<ITask> => {
         await _attachWorker(task.id, process.pid, workerCtx);
         await _updateTask(
@@ -299,7 +300,7 @@ export default function ({
     };
 
     const _detachWorker = async (taskId: string, ctx: IQueryInfos): Promise<void> => {
-        await _updateTask(taskId, {}, ctx);
+        await _updateTask(taskId, {workerId: null}, ctx);
     };
 
     const _getTasks = async ({params, ctx}: {params: IGetTasksParams; ctx: IQueryInfos}): Promise<IList<ITask>> => {


### PR DESCRIPTION
- Fix a wrong change during `strictNullChecks` implementation (https://github.com/leav-solutions/leav-engine/commit/cf01a3876438fd0783153a996c8345a5b848546e)

## Checklist

Definition Of Review

-   [x] Own code review done (add notes for others)
-   [x] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core - DataStudio - Admin - @leav/ui - @leav/utils - ...

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
