### PR TITLE
chore: eslint no-only-tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     ignorePatterns: ['**/_gqlTypes/*.ts', '**/dist/*', '**/plugins/*', '**/__generated__/**'],
     parser: '@typescript-eslint/parser',
     parserOptions: {tsconfigRootDir: __dirname},
-    plugins: ['@typescript-eslint', 'react-refresh'],
+    plugins: ['@typescript-eslint', 'react-refresh', 'no-only-tests'],
     settings: {react: {version: 'latest'}},
     extends: ['plugin:@aristid/recommended'],
     rules: {
@@ -133,5 +133,13 @@ module.exports = {
         'object-curly-spacing': ['error', 'never'],
         'func-call-spacing': ['error', 'never'],
         'react-refresh/only-export-components': 'warn'
-    }
+    },
+    overrides: [
+        {
+            files: ['**/*.test.ts', '**/*.spec.ts', '**/*.test.tsx', '**/*.spec.tsx'],
+            rules: {
+                'no-only-tests/no-only-tests': 'error'
+            }
+        }
+    ]
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsdoc": "39.2.1",
     "eslint-plugin-jsx-a11y": "6.5.1",
+    "eslint-plugin-no-only-tests": "3.3.0",
     "eslint-plugin-react-hooks": "4.4.0",
     "eslint-plugin-react-refresh": "0.4.3",
     "husky": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19127,6 +19127,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-no-only-tests@npm:3.3.0":
+  version: 3.3.0
+  resolution: "eslint-plugin-no-only-tests@npm:3.3.0"
+  checksum: 1b3a88e392113240758405966047ef40dd742fbd828f3c8d02a207125edaa5303ef9a0319a778551bd88789110423221fff4e9db02896c20836389b13c27b32e
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react-hooks@npm:4.4.0, eslint-plugin-react-hooks@npm:^4.3.0":
   version: 4.4.0
   resolution: "eslint-plugin-react-hooks@npm:4.4.0"
@@ -25342,6 +25349,7 @@ __metadata:
     eslint-plugin-import: "npm:2.26.0"
     eslint-plugin-jsdoc: "npm:39.2.1"
     eslint-plugin-jsx-a11y: "npm:6.5.1"
+    eslint-plugin-no-only-tests: "npm:3.3.0"
     eslint-plugin-react-hooks: "npm:4.4.0"
     eslint-plugin-react-refresh: "npm:0.4.3"
     husky: "npm:6.0.0"


### PR DESCRIPTION
to avoid commit/merge test files with .only (involuntary reduce test coverage),
As in [#963](https://github.com/leav-solutions/leav-engine/pull/963/files#diff-67d69cc856cb074b7201fb5cc30699568b491017dc8ff5fa82fbc9d9e48c1667R1133), fixed in https://github.com/leav-solutions/leav-engine/pull/975

## Checklist

Definition Of Review

-   [ ] Own code review done (add notes for others)
-   [ ] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core - DataStudio - Admin - @leav/ui - @leav/utils - ...

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
