### PR TITLE
chore(docker): plugins_install.sh yarn --production

### DIFF
--- a/docker/scripts/plugins_install.sh
+++ b/docker/scripts/plugins_install.sh
@@ -1,6 +1,11 @@
 pluginsFolder=/app/apps/core/dist/plugins
 
+# By default, that should be yarn@1 in base nodejs docker image
+yarn --version
+
 find $pluginsFolder -name package.json -not -path "*/node_modules/*" -exec sh -c '
   echo "🚧 Install dependencies for plugin $(basename $(dirname {}))"
-  (cd $(dirname {}) && touch "$plugin"yarn.lock && yarn install)
+  (cd $(dirname {}) && touch yarn.lock && yarn install --production --non-interactive)
 ' \;
+
+yarn cache clean


### PR DESCRIPTION
- For now, yarn version installed in leav/core is yarn@1, keep it for now.
- However, plugins could embed their version of yarn, and even use another package manager like npm.
- We need to refactor how plugins are embed in core and installed, but later.
- For https://aristid.atlassian.net/browse/LEAVC-189

## Checklist

Definition Of Review

-   [ ] Own code review done (add notes for others)
-   [ ] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core - DataStudio - Admin - @leav/ui - @leav/utils - ...

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
