### PR TITLE
feat(core): deactivate linked record when deleting reverse simple link

### DIFF
--- a/apps/core/src/__tests__/e2e/api/values/values.test.ts
+++ b/apps/core/src/__tests__/e2e/api/values/values.test.ts
@@ -887,7 +887,7 @@ describe('Values', () => {
                 );
             });
 
-            test('Delete value should remove simple link from linked record', async () => {
+            test('Delete value should remove simple link from linked record and deactivate linked record', async () => {
                 const res = await makeGraphQlCall(`mutation {
                     deleteValue(
                         library: "${testLibName}",
@@ -909,18 +909,23 @@ describe('Values', () => {
                 expect(res.data.data.deleteValue[0].id_value).toBe(advancedReverseSimpleLinkValueId);
                 expect(res.data.data.deleteValue[0].payload.id).toBe(recordIdSimpleLink);
 
-                expect(await getSimpleLinkLinkedRecord(recordIdSimpleLink)).toBeUndefined();
+                expect(await getSimpleLinkLinkedRecord(recordIdSimpleLink, true)).toBeUndefined();
                 expect(await getReverseLinkFromRecord(recordIdReverseLink)).toHaveLength(0);
             });
         });
 
-        async function getSimpleLinkLinkedRecord(recId: string): Promise<ILinkValue | undefined> {
+        async function getSimpleLinkLinkedRecord(
+            recId: string,
+            expectInactive = false
+        ): Promise<ILinkValue | undefined> {
             const resLinkedRecord = await makeGraphQlCall(`query {
                     records(
                         library: "${testLibName}",
-                        filters: [ { field: "id", condition: ${AttributeCondition.EQUAL}, value: "${recId}" }]
+                        filters: [ { field: "id", condition: ${AttributeCondition.EQUAL}, value: "${recId}" }],
+                        retrieveInactive: ${expectInactive}
                     ) {
                         list {
+                            active
                             property (attribute: "${attrSimpleLinkName}") {
                                 id_value
                                 ... on LinkValue {
@@ -935,6 +940,7 @@ describe('Values', () => {
 
             expect(resLinkedRecord.status).toBe(200);
             expect(resLinkedRecord.data.errors).toBeUndefined();
+            expect(resLinkedRecord.data.data.records.list[0].active).toBe(!expectInactive);
 
             return resLinkedRecord.data.data.records.list[0].property[0];
         }

--- a/apps/core/src/domain/value/valueDomain.ts
+++ b/apps/core/src/domain/value/valueDomain.ts
@@ -401,6 +401,23 @@ const valueDomain = function ({
             ctx
         );
 
+    const _maybeDeactivateLinkedRecord = async (
+        attributeProps: IAttribute,
+        reverseLink: IAttribute | undefined,
+        deletedValues: IValue[],
+        ctx: IQueryInfos
+    ): Promise<void> => {
+        if (attributeProps.type === AttributeTypes.ADVANCED_LINK && reverseLink?.type === AttributeTypes.SIMPLE_LINK) {
+            await saveValue({
+                library: attributeProps.linked_library,
+                recordId: deletedValues[0].payload.id,
+                attribute: 'active',
+                value: {payload: false},
+                ctx
+            });
+        }
+    };
+
     const _executeDeleteValue = async ({library, recordId, attribute, value, ctx}: IDeleteValueParams) => {
         // Check permission
         const canUpdateRecord = await recordPermissionDomain.getRecordPermission({
@@ -430,7 +447,7 @@ const valueDomain = function ({
 
         const attributeProps = await attributeDomain.getAttributeProperties({id: attribute, ctx});
 
-        let reverseLink: IAttribute;
+        let reverseLink: IAttribute | undefined;
         if (!!attributeProps.reverse_link) {
             reverseLink = await attributeDomain.getAttributeProperties({
                 id: attributeProps.reverse_link as string,
@@ -523,6 +540,8 @@ const valueDomain = function ({
                 return deletedValue;
             })
         );
+
+        await _maybeDeactivateLinkedRecord(attributeProps, reverseLink, deletedValues, ctx);
 
         await _maybeDeleteJoinRecord(attributeProps, deletedValues, ctx);
 


### PR DESCRIPTION
- Based on #989 
- For https://aristid.atlassian.net/browse/LEAVC-183
- Pas de suppression du record, une simple désactivation.

## Checklist

Definition Of Review

-   [ ] Own code review done (add notes for others)
-   [ ] Write message in teams channel
    ```
     <Title>

    *️⃣ Impacted projects : Core - DataStudio - Admin - @leav/ui - @leav/utils - ...

    📖 Ticket: https://aristid.atlassian.net/browse/<JIRA_TICKET_IDENTIFIER>

    🧑‍💻 PR: <link to PR/MR>

    ℹ Info: <brief explanation - context - how to test>
    ```

Definition Of Mergeable

-   [ ] 2 approves
-   [ ] 1 functional review - US has been tested
-   [ ] Every comment is handled - blocking ones have been resolved by reviewer
-   [ ] Design OK
-   [ ] Can be tested by POs
-   [ ] PR was introduced during daily meeting
